### PR TITLE
Add rst version of job posting

### DIFF
--- a/engjob.rst
+++ b/engjob.rst
@@ -1,0 +1,64 @@
+Decentralized Systems Engineer
+==============================
+
+BigchainDB is unlocking the promise of blockchains by giving them scale,
+using distributed database technology. We serve the open internet and
+enterprises alike, from supply chain to energy to financial ecosystems.
+
+You are someone that deeply cares about the future of the internet, of
+society. You love to build things. To you, coding is a delight.
+
+Responsibilities
+----------------
+
+-  You will design, implement, deploy, benchmark, and maintain
+   decentralized databases and software systems
+-  You will co-plan and co-design the product with your team in an
+   agile, open-source development process
+
+Minimum Qualifications
+----------------------
+
+-  You have a Bachelor's in Software Engineering, Computer Science, or
+   related discipline; or equivalent practical experience
+-  You love Python, and have 3+ years of production experience
+-  You have experience with distributed systems, backend development,
+   and web-based tech
+-  You possess good communication skills; interacting with your team and
+   other teams will be an integral part of your daily routine
+-  You are a creative, “make it happen” problem solver
+
+Preferred Qualifications
+------------------------
+
+-  You have a Master’s or PhD in distributed systems, or a related field
+-  You have engineered distributed databases, networking protocols, or
+   large-scale transaction systems
+-  You've worked with: consensus protocols; Linked Data / Semantic Web;
+   C, C++, Go, Rust, Haskell, Erlang, Clojure, Solidity
+-  As a bonus, we'd love to hear about cool stuff you've done with: new
+   decentralization protocols and tech (Bitcoin, IPFS / libp2p / IPLD,
+   Ethereum / devp2p, Tendermint / TMSP, Interledger), asynchronous
+   Python, container orchestration (Kubernetes, Swarm, Mesosphere,
+   Fleet), databases (ORM, SQL, noSQL, newSQL)
+
+Position Details
+----------------
+
+-  Location: Berlin
+-  Type: Permanent
+-  Salary: To Be Communicated
+
+We're a tight-knit international team based in Berlin. We’re always
+building and always shipping, but with an appreciation for the
+theoretical. We work closely with Ethereum, IPFS, Interledger, and other
+leaders in the blockchain space.
+
+We are an equal opportunity employer and value diversity at our company.
+We do not discriminate on the basis of race, religion, color, national
+origin, gender, sexual orientation, age, marital status, veteran status,
+or disability status.
+
+Are you up for working with an awesome team, learning a ton, and
+shipping code that matters? Please email engjob@bigchaindb.com, with
+your cover letter, resume, and code samples (e.g. GitHub profile).


### PR DESCRIPTION
**NOTE**: the Python Job Board requires rst, and hence this PR is to version the rst file to save time so we do not need to reconvert the markdown each time.