### PR TITLE
First-pass update to ROADMAP.md: goals for BigchainDB 2.1+

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -84,7 +84,7 @@ There's a loose collection of some BigchainDB 2.0 "TODO" items in the GitHub org
 - Scale-up and scale-out strategy. Define limits - run infra load tests.
 - Propose a new transaction model that:
   - doesn't use crypto-conditions
-  - supports the Ethereum signature scheme, i.e. secp256k1 keys
+  - supports the signature scheme used by Ethereum, i.e. secp256k1 keys
 
 #### Priority 3
 
@@ -100,7 +100,7 @@ There's a loose collection of some BigchainDB 2.0 "TODO" items in the GitHub org
 
 #### Priority 1
 
-- Support smart contracts via:
+- Support smart contracts (and create new marketing channels) via:
   - integration with Ethereum
   - integration with Hyperledger Fabric
 
@@ -119,13 +119,14 @@ There's a loose collection of some BigchainDB 2.0 "TODO" items in the GitHub org
 
 ### Other Goals for BigchainDB 2.1 and Beyond
 
+- Integration with Polkadot.
 - Scalability
 - Native support for CRUD/CRAB.
 - Have only one backend to store all data, i.e. don't store all data in both MongoDB and LevelDB.
 - Document how to run a production validator.
   - Recommended configuration settings.
   - Sentry nodes for public networks, to hide the IP addresses of validators; see issue https://github.com/bigchaindb/bigchaindb/issues/2333).
-- Performance optimization by removing unneeded deepcopy operations.
+- More performance optimizations, e.g. by removing unneeded deepcopy operations.
 - New way to compute the app hash based on the UTXO set, including an efficient way to update the Merkle tree used to compute the app hash from the UTXO set.
 - Support hashlock conditions (securely: need to make sure that every transaction is still signed by a client)
 - Support timelock conditions

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -69,18 +69,68 @@ There's a loose collection of some BigchainDB 2.0 "TODO" items in the GitHub org
 
 ## Some Goals for BigchainDB 2.1 and Beyond
 
-- Document how to run a production validator so that it's protected from denial-of-service (DoS) attacks and similar issues. See what Tendermint recommends (i.e. "sentry nodes", see issue https://github.com/bigchaindb/bigchaindb/issues/2333).
+### Short-Term Goals - Low-Hanging Fruits
+
+#### Priority 1
+
+- Better node deployment and setup process. Analyze and ask users their issues. Define an action plan (BEP).
+- Privacy using encryption, using plugins
+  - node level encryption
+  - peer to peer encryption on same node - needs KMS
+
+#### Priority 2
+
+- Plugin architecture for transaction validation. Refactor the tx code: BEP-9. Generalize the codebase. Dynamic loading of plugins using validator election.
+- Scale-up and scale-out strategy. Define limits - run infra load tests.
+- Propose a new transaction model that:
+  - doesn't use crypto-conditions
+  - supports the Ethereum signature scheme, i.e. secp256k1 keys
+
+#### Priority 3
+
+- Key management support
+
+#### Priority 4
+
+- Ability to delete past transactions. This is an approach to GDPR compliance (e.g. the "right to be forgotten"). If a user has access to keys, let them instigate deletion, otherwise the nodes must vote on deletion. The modified blockchain must still be valid, somehow (when replayed).
+- Scale-up and scale-out strategy. Documentation to educate users why there is a limit. Add another local mempool for capacity (i.e. to moderate the load on the existing mempool).
+- Privacy using zero-knowledge proofs.
+
+### Medium-Term Goals - Journey Projects
+
+#### Priority 1
+
+- Support smart contracts via:
+  - integration with Ethereum
+  - integration with Hyperledger Fabric
+
+#### Priority 2
+
+- Support for light clients.
+
+#### Priority 3
+
+- Asset sharding: give more schema control to users.
+
+### Priority 4
+
+- Asset sharding: Different MongoDB collections for different asset types.
+- System-level and user-level transactions.
+
+### Other Goals for BigchainDB 2.1 and Beyond
+
+- Scalability
+- Native support for CRUD/CRAB.
+- Have only one backend to store all data, i.e. don't store all data in both MongoDB and LevelDB.
+- Document how to run a production validator.
+  - Recommended configuration settings.
+  - Sentry nodes for public networks, to hide the IP addresses of validators; see issue https://github.com/bigchaindb/bigchaindb/issues/2333).
 - Performance optimization by removing unneeded deepcopy operations.
-- Example projects showing how to use BigchainDB with other decentralized systems, especially Ethereum.
-- Refactoring, especially of the transaction-related code.
 - New way to compute the app hash based on the UTXO set, including an efficient way to update the Merkle tree used to compute the app hash from the UTXO set.
-- No more 3scale (currently used by the BigchainDB Testnet)
 - Support hashlock conditions (securely: need to make sure that every transaction is still signed by a client)
 - Support timelock conditions
-- (?) LevelDB vs other backends in Tendermint?
-- Plugins/extensions for specialized use cases
-- Smart contract support. (Not necessarily within BigchainDB; maybe just better documentation about how to integrate with other smart-contract blockchains.)
 - Test what happens when a node runs out of memory or hard drive space. For example, what happens when there's no more space for MongoDB to write a block?
+- Stop using 3scale (currently used by the BigchainDB Testnet).
 
 ## BigchainDB 3.0?
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -71,6 +71,8 @@ There's a loose collection of some BigchainDB 2.0 "TODO" items in the GitHub org
 
 ### Short-Term Goals - Low-Hanging Fruits
 
+These are features which are solving a very specific problem. These features, while not scoped, are expected to be small to medium in implementation complexity.
+
 #### Priority 1
 
 - Better node deployment and setup process. Analyze and ask users their issues. Define an action plan (BEP).
@@ -97,6 +99,8 @@ There's a loose collection of some BigchainDB 2.0 "TODO" items in the GitHub org
 - Privacy using zero-knowledge proofs.
 
 ### Medium-Term Goals - Journey Projects
+
+These are typically a collection of features which are solving a much broader set of problems. These features can result in several [BigchainDB Enhancement Proposals (BEPs)](https://github.com/bigchaindb/BEPs) during scoping and are expected to be medium to large in implementation complexity.
 
 #### Priority 1
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,21 +76,21 @@ These are features which are solving a very specific problem. These features, wh
 #### Priority 1
 
 - Better node deployment and setup process. Analyze and ask users their issues. Define an action plan (BEP).
-- Privacy using encryption, using plugins
+- Data privacy features with (optional) support for encryption using a more modular plugins-based approach.
   - node level encryption
   - peer to peer encryption on same node - needs KMS
 
 #### Priority 2
 
 - Plugin architecture for transaction validation. Refactor the tx code: BEP-9. Generalize the codebase. Dynamic loading of plugins using validator election.
-- Scale-up and scale-out strategy. Define limits - run infra load tests.
+- Defining scale-up and scale-out strategies for nodes in a network expecting larger loads. As a first step, running load tests to find infrastructure limit.
 - Propose a new transaction model that:
   - doesn't use crypto-conditions
   - supports the signature scheme used by Ethereum, i.e. secp256k1 keys
 
 #### Priority 3
 
-- Key management support
+- Support for key management solution for easier access and better integration.
 
 #### Priority 4
 
@@ -114,11 +114,10 @@ These are typically a collection of features which are solving a much broader se
 
 #### Priority 3
 
-- Asset sharding: give more schema control to users.
+- Allow network admins and node admins to define their own MongoDB collections and indexes for better control over schemas.
 
 ### Priority 4
 
-- Asset sharding: Different MongoDB collections for different asset types.
 - System-level and user-level transactions.
 
 ### Other Goals for BigchainDB 2.1 and Beyond


### PR DESCRIPTION
This pull request updates the BigchainDB roadmap (ROADMAP.md) for BigchainDB 2.1 and beyond, based on what we discussed in the recent BigchainDB offsite planning meeting.

I intend to leave it open for review for a while before merging it.

The first commit (https://github.com/bigchaindb/org/commit/105b6c02937e644d1181072f2890cf4de9794cc7) is a first cut. I will probably revise this pull request based on some other notes (i.e. in another commit) before I merge it.